### PR TITLE
Update setup test cases and added installer only option

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -292,12 +292,12 @@ jobs:
         generation: 3.5.21.0
         patch: 0
         architecture: 64
-        installation-directory: "C:\\CustomCODESYS"
+        installation-directory: "C:\\Custom_Directory_CODESYS"
 
     - name: Verify custom installation
       shell: pwsh
       run: |
-        $expectedPath = "C:\CustomCODESYS"
+        $expectedPath = "C:\Custom_Directory_CODESYS"
         $actualPath = "${{ steps.setup_custom.outputs.codesys-path }}"
 
         if ($actualPath -eq $expectedPath) {

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -5,12 +5,32 @@ on:
     branches:
       - main
       - update-*
-      - migrate-*
-      - addons-*
     paths-ignore:
       - 'README.md'
 
 jobs:
+  setup-installer-only:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup CODESYS Installer Only
+      id: setup_installer
+      uses: ./
+      with:
+        installer-only: true
+        installer-version: 2.4.1
+        auto-update-installer: true
+
+    - name: Test installer outputs
+      shell: bash
+      run: |
+        echo "Installer path: ${{ steps.setup_installer.outputs.installer-path }}"
+        echo "Installer CLI executable: ${{ steps.setup_installer.outputs.installer-cli-executable }}"
+
   setup-installation:
     strategy:
       matrix:
@@ -67,8 +87,8 @@ jobs:
           ${{ steps.setup_codesys.outputs.installation-info-file-path }}
           ${{ steps.setup_codesys.outputs.add-ons-info-file-path }}
     
-  # Example/Test 2: job to install CODESYS with add-ons from list
-  setup-installation-with-addons-case01:
+  # Test: Install with add-ons from ID list
+  addons-from-list:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -95,13 +115,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: warn
-        name: case01-info-files
+        name: addons-list-info-files
         path: |
           ${{ steps.setup_codesys.outputs.installation-info-file-path }}
           ${{ steps.setup_codesys.outputs.add-ons-info-file-path }}
 
-  # Example/Test 2: job to install CODESYS from add-on package file
-  setup-installation-with-addons-case02:
+  # Test: Install with add-ons from package files
+  addons-from-packages:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -127,13 +147,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: warn
-        name: case02-info-files
+        name: addons-packages-info-files
         path: |
           ${{ steps.setup_codesys.outputs.installation-info-file-path }}
           ${{ steps.setup_codesys.outputs.add-ons-info-file-path }}
 
-  # Example/Test 3: job to install CODESYS with add-ons from list and package file
-  setup-installation-with-addons-case03:
+  # Test: Install with mixed add-on sources
+  addons-mixed-sources:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -163,13 +183,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: warn
-        name: case03-info-files
+        name: addons-mixed-info-files
         path: |
           ${{ steps.setup_codesys.outputs.installation-info-file-path }}
           ${{ steps.setup_codesys.outputs.add-ons-info-file-path }}
 
-  # Example/Test 4: job to install CODESYS with custom package file only
-  setup-installation-with-addons-case04:
+  # Test: Install with installer import config
+  addons-from-import-config:
     runs-on: windows-latest
     permissions:
       contents: read
@@ -193,7 +213,206 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: warn
-        name: case04-info-files
+        name: addons-import-info-files
         path: |
           ${{ steps.setup_codesys.outputs.installation-info-file-path }}
           ${{ steps.setup_codesys.outputs.add-ons-info-file-path }}
+
+  # Test: Multiple CODESYS versions in same job
+  multiple-installations:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install CODESYS 3.5.20.0 (64-bit)
+      id: codesys_3_5_20_0_x64
+      uses: ./
+      with:
+        installer-version: 2.4.1
+        auto-update-installer: false
+        generation: 3.5.20.0
+        architecture: 64
+        patch: 0
+
+    - name: Install CODESYS 3.5.21.2 (64-bit)
+      id: codesys_3_5_21_2_x64
+      uses: ./
+      with:
+        installer-version: 2.4.1
+        auto-update-installer: false
+        generation: 3.5.21.0
+        architecture: 64
+        patch: 2
+
+    - name: Install CODESYS 3.5.19.6 (32-bit)
+      id: codesys_3_5_19_6_x86
+      uses: ./
+      with:
+        installer-version: 2.4.1
+        auto-update-installer: false
+        generation: 3.5.19.0
+        architecture: 32
+        patch: 6
+
+    - name: Verify all installations
+      shell: pwsh
+      run: |
+        $installations = @(
+          @{ Path = "${{ steps.codesys_3_5_20_0_x64.outputs.codesys-executable }}"; Version = "3.5.20.0" },
+          @{ Path = "${{ steps.codesys_3_5_21_2_x64.outputs.codesys-executable }}"; Version = "3.5.21.2" },
+          @{ Path = "${{ steps.codesys_3_5_19_6_x86.outputs.codesys-executable }}"; Version = "3.5.19.6" }
+        )
+
+        foreach ($install in $installations) {
+          if (Test-Path $install.Path) {
+            Write-Host "CODESYS $($install.Version) found at: $($install.Path)"
+          } else {
+            Write-Host "CODESYS $($install.Version) not found at: $($install.Path)"
+            exit 1
+          }
+        }
+
+  # Test: Custom installation directory
+  custom-directory:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup CODESYS with custom directory
+      id: setup_custom
+      uses: ./
+      with:
+        installer-version: 2.4.1
+        generation: 3.5.21.0
+        patch: 0
+        architecture: 64
+        installation-directory: "C:\\CustomCODESYS"
+
+    - name: Verify custom installation
+      shell: pwsh
+      run: |
+        $expectedPath = "C:\CustomCODESYS"
+        $actualPath = "${{ steps.setup_custom.outputs.codesys-path }}"
+
+        if ($actualPath -eq $expectedPath) {
+          Write-Host "Installation path matches custom directory: $actualPath"
+        } else {
+          Write-Host "Expected: $expectedPath"
+          Write-Host "Actual: $actualPath"
+          exit 1
+        }
+
+        if (Test-Path "$actualPath\CODESYS\Common\CODESYS.exe") {
+          Write-Host "CODESYS executable found in custom directory"
+        } else {
+          Write-Host "CODESYS executable not found in custom directory"
+          exit 1
+        }
+
+  # Test: Installer-only followed by installation
+  installer-then-install:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: First install installer only
+      id: installer_only
+      uses: ./
+      with:
+        installer-only: true
+        installer-version: 2.4.1
+        auto-update-installer: true
+
+    - name: Verify installer is available
+      shell: pwsh
+      run: |
+        $installerCli = "${{ steps.installer_only.outputs.installer-cli-executable }}"
+        if (Test-Path $installerCli) {
+          Write-Host "Installer CLI available at: $installerCli"
+        } else {
+          Write-Host "Installer CLI not found"
+          exit 1
+        }
+
+    - name: Now install CODESYS using existing installer
+      id: install_codesys
+      uses: ./
+      with:
+        installer-version: 2.4.1
+        auto-update-installer: false
+        generation: 3.5.21.0
+        patch: 2
+        architecture: 64
+
+    - name: Verify CODESYS installation
+      shell: pwsh
+      run: |
+        $codesysExe = "${{ steps.install_codesys.outputs.codesys-executable }}"
+        if (Test-Path $codesysExe) {
+          Write-Host "CODESYS installed successfully at: $codesysExe"
+        } else {
+          Write-Host "CODESYS installation failed"
+          exit 1
+        }
+
+  # Test: Edge cases and validation
+  edge-cases:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        test:
+          - name: "minimum-patch"
+            generation: "3.5.20.0"
+            patch: "0"
+            architecture: "64"
+          - name: "32bit-with-addons"
+            generation: "3.5.21.0"
+            patch: "2"
+            architecture: "32"
+            install-addons: true
+            addon-list: "dd6c2da4-2ed2-4076-9bf7-52394db68819,1.6.0.0"
+          - name: "latest-installer"
+            generation: "3.5.21.0"
+            patch: "2"
+            architecture: "64"
+            installer-version: "2.4.1"
+            auto-update: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Test ${{ matrix.test.name }}
+      id: test_setup
+      uses: ./
+      with:
+        installer-version: ${{ matrix.test.installer-version || '2.4.1' }}
+        auto-update-installer: ${{ matrix.test.auto-update || 'false' }}
+        generation: ${{ matrix.test.generation }}
+        patch: ${{ matrix.test.patch }}
+        architecture: ${{ matrix.test.architecture }}
+        install-add-ons: ${{ matrix.test.install-addons || 'false' }}
+        add-ons-list: ${{ matrix.test.addon-list || '' }}
+
+    - name: Validate installation
+      shell: pwsh
+      run: |
+        Write-Host "Testing: ${{ matrix.test.name }}"
+        $codesysPath = "${{ steps.test_setup.outputs.codesys-path }}"
+        if (Test-Path "$codesysPath\CODESYS\Common\CODESYS.exe") {
+          Write-Host "Test passed: ${{ matrix.test.name }}"
+        } else {
+          Write-Host "Test failed: ${{ matrix.test.name }}"
+          exit 1
+        }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 
 ## Usage examples
 
+- Install the CODESYS Installer without a CODESYS installation.
+```yml
+  - name: Setup CODESYS Installer Only
+    uses: powerIO-GmbH/action-codesys-setup@v1
+    with:
+      installer-only: true
+      installer-version: 2.4.1
+      auto-update-installer: true
+```
+
 - Install CODESYS Version `3.5.20.4`:
 ```yml
   - name: Setup CODESYS
@@ -68,6 +78,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|----------|
+| `installer-only` | If set to `true`, only the installer will be installed without a CODESYS installation. | false | `false` |
 | `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.4.1` |
 | `generation` | This is the base generation you want to install (e.g., `3.5.21.0`). Even if you want to install version `3.5.21.2`, you have to define the generation as `3.5.21.0`. The patch version is defined by the `patch` input. | false | `3.5.21.0` |
 | `architecture` | The installation architecture of CODESYS. Allowed inputs: `32` and `64`. | false | `64` |
@@ -85,9 +96,9 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 
 | Output                        | Description                                       |
 | ----------------------------- | ------------------------------------------------- |
-| `codesys-path`                | The path of the installed CODESYS version.        |
-| `codesys-executable`          | The path of the CODESYS executable.               |
+| `codesys-path`                | The path of the installed CODESYS version. (Not available when `installer-only` is true) |
+| `codesys-executable`          | The path of the CODESYS executable. (Not available when `installer-only` is true) |
 | `installer-path`              | The path of the installed CODESYS installer.      |
 | `installer-cli-executable`    | The path of the CODESYS installer CLI executable. |
-| `installation-info-file-path` | The path of the installation information file.    |
-| `add-ons-info-file-path`      | The path of the add-ons information file.         |
+| `installation-info-file-path` | The path of the installation information file. (Not available when `installer-only` is true) |
+| `add-ons-info-file-path`      | The path of the add-ons information file. (Not available when `installer-only` is true) |

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,11 @@ branding:
   color: "red"
 
 inputs:
+  installer-only:
+    description: "If set to `true`, only the installer will be installed without a CODESYS installation."
+    required: false
+    default: false
+
   installer-version:
     description: "The version of the installer to use to install the CODESYS installation."
     required: false
@@ -182,7 +187,8 @@ runs:
 
         Write-Host "::endgroup::"
 
-    - name: Prepare and validate inputs
+    - if: ${{ inputs.installer-only != 'true' }}
+      name: Prepare and validate inputs
       id: parameter_validation
       shell: pwsh
       run: | # powershell
@@ -232,7 +238,8 @@ runs:
 
         Write-Host "::endgroup::"
 
-    - name: Install CODESYS
+    - if: ${{ inputs.installer-only != 'true' }}
+      name: Install CODESYS
       shell: pwsh
       run: | # powershell
         Write-Host "::group::Install CODESYS"
@@ -278,7 +285,8 @@ runs:
         Write-Host "Finished installation"
         Write-Host "::endgroup::"
 
-    - name: Decide add-ons path
+    - if: ${{ inputs.installer-only != 'true' }}
+      name: Decide add-ons path
       id: add_ons_path
       shell: pwsh
       run: | # powershell
@@ -309,7 +317,7 @@ runs:
 
         Write-Host "::endgroup::"
 
-    - if: (inputs.install-add-ons == 'true' && inputs.add-ons-list != '')
+    - if: (inputs.installer-only != 'true' && inputs.install-add-ons == 'true' && inputs.add-ons-list != '')
       name: Install Add-ons from text entry list
       shell: pwsh
       run: | # powershell
@@ -346,7 +354,7 @@ runs:
 
         Write-Host "::endgroup::"
 
-    - if: (inputs.install-add-ons == 'true' && inputs.add-ons-from-file-list != '')
+    - if: (inputs.installer-only != 'true' && inputs.install-add-ons == 'true' && inputs.add-ons-from-file-list != '')
       name: Install Add-ons from file list
       shell: pwsh
       run: | # powershell
@@ -381,7 +389,7 @@ runs:
 
         Write-Host "::endgroup::"
 
-    - if: (inputs.install-add-ons == 'true' && inputs.add-ons-installer-import-file != '')
+    - if: (inputs.installer-only != 'true' && inputs.install-add-ons == 'true' && inputs.add-ons-installer-import-file != '')
       name: Install Add-ons from installer import file (.installation-config)
       shell: pwsh
       run: | # powershell
@@ -408,7 +416,8 @@ runs:
         Write-Host "Finished installing addons from import file"
         Write-Host "::endgroup::"
 
-    - name: Show installation information
+    - if: ${{ inputs.installer-only != 'true' }}
+      name: Show installation information
       id: install_info
       shell: pwsh
       run: | # powershell


### PR DESCRIPTION
This pull request adds support for installing only the CODESYS Installer (without a full CODESYS installation) and introduces comprehensive tests and documentation updates for this new feature. It also improves the structure and naming of test jobs in the GitHub Actions workflow for better clarity, and enhances validation and edge case coverage.

**Installer-only mode and documentation:**

* Added a new `installer-only` input to the GitHub Action (`action.yml`), allowing users to install just the CODESYS Installer without a CODESYS installation. Conditional steps ensure that installation and add-on logic are skipped when `installer-only` is true. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R10-R14) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L185-R191) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L235-R242) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L281-R289) [[5]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L312-R320) [[6]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L349-R357) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L384-R392) [[8]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L411-R420)
* Updated the `README.md` with usage examples, input/output documentation, and notes about which outputs are available in `installer-only` mode. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R104)

**Workflow and test improvements:**

* Added new jobs to `.github/workflows/setup.yml` to test the installer-only mode, multiple CODESYS installations in one job, custom installation directories, sequential installer and installation steps, and various edge cases. [[1]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L8-R33) [[2]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L196-R418)
* Refactored and renamed existing test jobs for clarity, grouping them by add-on installation method and improving artifact naming. [[1]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L70-R91) [[2]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L98-R124) [[3]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L130-R156) [[4]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L166-R192)