### PR TITLE
Update default installer and added codesys installer version note

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -22,7 +22,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
 
     - name: Test installer outputs
@@ -64,7 +64,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: false
         generation: ${{ matrix.generation }}
         architecture: ${{ matrix.architecture }}
@@ -100,7 +100,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 2
@@ -133,7 +133,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 2
@@ -165,7 +165,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 2
@@ -201,7 +201,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 2
@@ -231,7 +231,7 @@ jobs:
       id: codesys_3_5_20_0_x64
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: false
         generation: 3.5.20.0
         architecture: 64
@@ -241,7 +241,7 @@ jobs:
       id: codesys_3_5_21_2_x64
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: false
         generation: 3.5.21.0
         architecture: 64
@@ -251,7 +251,7 @@ jobs:
       id: codesys_3_5_19_6_x86
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: false
         generation: 3.5.19.0
         architecture: 32
@@ -288,7 +288,7 @@ jobs:
       id: setup_custom
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         generation: 3.5.21.0
         patch: 0
         architecture: 64
@@ -329,7 +329,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
 
     - name: Verify installer is available
@@ -347,7 +347,7 @@ jobs:
       id: install_codesys
       uses: ./
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: false
         generation: 3.5.21.0
         patch: 2
@@ -386,7 +386,7 @@ jobs:
             generation: "3.5.21.0"
             patch: "2"
             architecture: "64"
-            installer-version: "2.4.1"
+            installer-version: "2.5.0"
             auto-update: true
 
     steps:
@@ -397,7 +397,7 @@ jobs:
       id: test_setup
       uses: ./
       with:
-        installer-version: ${{ matrix.test.installer-version || '2.4.1' }}
+        installer-version: ${{ matrix.test.installer-version || '2.5.0' }}
         auto-update-installer: ${{ matrix.test.auto-update || 'false' }}
         generation: ${{ matrix.test.generation }}
         patch: ${{ matrix.test.patch }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -22,7 +22,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
 
     - name: Test installer outputs
@@ -66,7 +66,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: false
         generation: ${{ matrix.generation }}
         architecture: ${{ matrix.architecture }}
@@ -102,7 +102,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 3
@@ -135,7 +135,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 3
@@ -167,7 +167,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 3
@@ -203,7 +203,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
         generation: 3.5.21.0
         patch: 3
@@ -233,7 +233,7 @@ jobs:
       id: codesys_3_5_20_0_x64
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: false
         generation: 3.5.20.0
         architecture: 64
@@ -243,7 +243,7 @@ jobs:
       id: codesys_3_5_21_2_x64
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: false
         generation: 3.5.21.0
         architecture: 64
@@ -253,7 +253,7 @@ jobs:
       id: codesys_3_5_19_6_x86
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: false
         generation: 3.5.19.0
         architecture: 32
@@ -290,7 +290,7 @@ jobs:
       id: setup_custom
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         generation: 3.5.21.0
         patch: 0
         architecture: 64
@@ -331,7 +331,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
 
     - name: Verify installer is available
@@ -349,7 +349,7 @@ jobs:
       id: install_codesys
       uses: ./
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: false
         generation: 3.5.21.0
         patch: 2
@@ -388,7 +388,7 @@ jobs:
             generation: "3.5.21.0"
             patch: "2"
             architecture: "64"
-            installer-version: "2.5.0"
+            installer-version: "2.5.0.0"
             auto-update: true
 
     steps:
@@ -399,7 +399,7 @@ jobs:
       id: test_setup
       uses: ./
       with:
-        installer-version: ${{ matrix.test.installer-version || '2.5.0' }}
+        installer-version: ${{ matrix.test.installer-version || '2.5.0.0' }}
         auto-update-installer: ${{ matrix.test.auto-update || 'false' }}
         generation: ${{ matrix.test.generation }}
         patch: ${{ matrix.test.patch }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -52,6 +52,8 @@ jobs:
             patch: 3
           - generation: 3.5.21.0
             patch: 2
+          - generation: 3.5.21.0
+            patch: 3
 
     runs-on: windows-latest
     permissions:
@@ -103,7 +105,7 @@ jobs:
         installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 2
+        patch: 3
         architecture: 64
         install-add-ons: true
         add-ons-list: |
@@ -136,7 +138,7 @@ jobs:
         installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 2
+        patch: 3
         architecture: 64
         install-add-ons: true
         add-ons-from-file-list: |
@@ -168,7 +170,7 @@ jobs:
         installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 2
+        patch: 3
         architecture: 64
         install-add-ons: true
         add-ons-list: |
@@ -204,7 +206,7 @@ jobs:
         installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 2
+        patch: 3
         architecture: 64
         install-add-ons: true
         add-ons-installer-import-file: example/custom_import_files/example_import_add-ons.installation-config

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 > [!IMPORTANT]  
 > This action is only supported to run on windows OS.
 
+> [!WARNING]
+> From CODESYS Installer Version >= `2.5.0.0` CODESYS changed the Version format to `<Major>.<Minor>.<Patch>.<Fix|Build>`.
+> Versions < `2.5.0.0` used the Version format `<Major>.<Minor>.<Patch>`.
+> To use a specific version, check the CODESYS Installer versions from the [version history](https://store.codesys.com/en/codesys-installer.html#product.attributes.wrapper).
+
 ## Usage
 
 >:white_flag: See the [inputs](#inputs) section for detailed descriptions.
@@ -20,7 +25,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
   - name: Setup CODESYS
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
-      installer-version: 2.5.0
+      installer-version: 2.5.0.0
       auto-update-installer: false
       generation: 3.5.21.0
       architecture: 64
@@ -35,7 +40,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
       installer-only: true
-      installer-version: 2.5.0
+      installer-version: 2.5.0.0
       auto-update-installer: true
 ```
 
@@ -60,7 +65,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
       id: setup_codesys
       uses: powerIO-GmbH/action-codesys-setup@v1
       with:
-        installer-version: 2.5.0
+        installer-version: 2.5.0.0
         auto-update-installer: true
         generation: 3.5.20.0
         architecture: 64
@@ -79,7 +84,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 | Input | Description | Required | Default |
 |-------|-------------|----------|----------|
 | `installer-only` | If set to `true`, only the installer will be installed without a CODESYS installation. | false | `false` |
-| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.5.0` |
+| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.5.0.0` |
 | `generation` | This is the base generation you want to install (e.g., `3.5.21.0`). Even if you want to install version `3.5.21.2`, you have to define the generation as `3.5.21.0`. The patch version is defined by the `patch` input. | false | `3.5.21.0` |
 | `architecture` | The installation architecture of CODESYS. Allowed inputs: `32` and `64`. | false | `64` |
 | `patch` | The patch of the CODESYS version to install. | false | `0` |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
       auto-update-installer: false
       generation: 3.5.21.0
       architecture: 64
-      patch: 2
+      patch: 3
 ```
 
 ## Usage examples

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
   - name: Setup CODESYS
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
-      installer-version: 2.4.1
+      installer-version: 2.5.0
       auto-update-installer: false
       generation: 3.5.21.0
       architecture: 64
@@ -35,7 +35,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
       installer-only: true
-      installer-version: 2.4.1
+      installer-version: 2.5.0
       auto-update-installer: true
 ```
 
@@ -60,7 +60,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
       id: setup_codesys
       uses: powerIO-GmbH/action-codesys-setup@v1
       with:
-        installer-version: 2.4.1
+        installer-version: 2.5.0
         auto-update-installer: true
         generation: 3.5.20.0
         architecture: 64
@@ -79,7 +79,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 | Input | Description | Required | Default |
 |-------|-------------|----------|----------|
 | `installer-only` | If set to `true`, only the installer will be installed without a CODESYS installation. | false | `false` |
-| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.4.1` |
+| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.5.0` |
 | `generation` | This is the base generation you want to install (e.g., `3.5.21.0`). Even if you want to install version `3.5.21.2`, you have to define the generation as `3.5.21.0`. The patch version is defined by the `patch` input. | false | `3.5.21.0` |
 | `architecture` | The installation architecture of CODESYS. Allowed inputs: `32` and `64`. | false | `64` |
 | `patch` | The patch of the CODESYS version to install. | false | `0` |

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   installer-version:
     description: "The version of the installer to use to install the CODESYS installation."
     required: false
-    default: 2.5.0
+    default: 2.5.0.0
 
   generation:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   installer-version:
     description: "The version of the installer to use to install the CODESYS installation."
     required: false
-    default: 2.4.1
+    default: 2.5.0
 
   generation:
     description: >


### PR DESCRIPTION
This pull request updates the default CODESYS installer version used throughout the project from `2.4.1` to `2.5.0.0`, reflecting an upstream change in versioning format. The changes ensure that workflows, documentation, and configuration files are consistent with the new installer version and its requirements.

**Installer version and workflow updates:**

* Updated all references to the installer version from `2.4.1` to `2.5.0.0` in the `.github/workflows/setup.yml` file to standardize the version used in CI workflows. [[1]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L25-R25) [[2]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L67-R69) [[3]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L103-R108) [[4]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L136-R141) [[5]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L168-R173) [[6]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L204-R209) [[7]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L234-R236) [[8]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L244-R246) [[9]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L254-R256) [[10]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L291-R293) [[11]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L332-R334) [[12]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L350-R352) [[13]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L389-R391) [[14]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L400-R402)

**Documentation updates:**

* Updated the `README.md` to reflect the new default installer version and patch, including all usage examples and input tables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R43) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R68) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R87)

* Added a warning to the `README.md` explaining the new version format for installer versions `>= 2.5.0.0` and provided guidance for selecting the correct version.

**Configuration file update:**

* Changed the default installer version in `action.yml` to `2.5.0.0`.