### PR TITLE
Update to new version

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -22,7 +22,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
 
     - name: Test installer outputs
@@ -53,7 +53,7 @@ jobs:
           - generation: 3.5.21.0
             patch: 2
           - generation: 3.5.21.0
-            patch: 3
+            patch: 4
 
     runs-on: windows-latest
     permissions:
@@ -66,7 +66,7 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: false
         generation: ${{ matrix.generation }}
         architecture: ${{ matrix.architecture }}
@@ -102,10 +102,10 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 3
+        patch: 4
         architecture: 64
         install-add-ons: true
         add-ons-list: |
@@ -135,10 +135,10 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 3
+        patch: 4
         architecture: 64
         install-add-ons: true
         add-ons-from-file-list: |
@@ -167,10 +167,10 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 3
+        patch: 4
         architecture: 64
         install-add-ons: true
         add-ons-list: |
@@ -203,10 +203,10 @@ jobs:
       id: setup_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
         generation: 3.5.21.0
-        patch: 3
+        patch: 4
         architecture: 64
         install-add-ons: true
         add-ons-installer-import-file: example/custom_import_files/example_import_add-ons.installation-config
@@ -233,7 +233,7 @@ jobs:
       id: codesys_3_5_20_0_x64
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: false
         generation: 3.5.20.0
         architecture: 64
@@ -243,7 +243,7 @@ jobs:
       id: codesys_3_5_21_2_x64
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: false
         generation: 3.5.21.0
         architecture: 64
@@ -253,7 +253,7 @@ jobs:
       id: codesys_3_5_19_6_x86
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: false
         generation: 3.5.19.0
         architecture: 32
@@ -290,7 +290,7 @@ jobs:
       id: setup_custom
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         generation: 3.5.21.0
         patch: 0
         architecture: 64
@@ -331,7 +331,7 @@ jobs:
       uses: ./
       with:
         installer-only: true
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
 
     - name: Verify installer is available
@@ -349,7 +349,7 @@ jobs:
       id: install_codesys
       uses: ./
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: false
         generation: 3.5.21.0
         patch: 2
@@ -388,7 +388,7 @@ jobs:
             generation: "3.5.21.0"
             patch: "2"
             architecture: "64"
-            installer-version: "2.5.0.0"
+            installer-version: "2.6.0.0"
             auto-update: true
 
     steps:
@@ -399,7 +399,7 @@ jobs:
       id: test_setup
       uses: ./
       with:
-        installer-version: ${{ matrix.test.installer-version || '2.5.0.0' }}
+        installer-version: ${{ matrix.test.installer-version || '2.6.0.0' }}
         auto-update-installer: ${{ matrix.test.auto-update || 'false' }}
         generation: ${{ matrix.test.generation }}
         patch: ${{ matrix.test.patch }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
       installer-only: true
-      installer-version: 2.5.0.0
+      installer-version: 2.6.0.0
       auto-update-installer: true
 ```
 
@@ -65,7 +65,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
       id: setup_codesys
       uses: powerIO-GmbH/action-codesys-setup@v1
       with:
-        installer-version: 2.5.0.0
+        installer-version: 2.6.0.0
         auto-update-installer: true
         generation: 3.5.20.0
         architecture: 64

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
   - name: Setup CODESYS
     uses: powerIO-GmbH/action-codesys-setup@v1
     with:
-      installer-version: 2.5.0.0
+      installer-version: 2.6.0.0
       auto-update-installer: false
       generation: 3.5.21.0
       architecture: 64
-      patch: 3
+      patch: 4
 ```
 
 ## Usage examples
@@ -84,7 +84,7 @@ It can also be used to process test cases or other CI/CD jobs in your workflow.
 | Input | Description | Required | Default |
 |-------|-------------|----------|----------|
 | `installer-only` | If set to `true`, only the installer will be installed without a CODESYS installation. | false | `false` |
-| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.5.0.0` |
+| `installer-version` | The version of the installer to use to install the CODESYS installation. | false | `2.6.0.0` |
 | `generation` | This is the base generation you want to install (e.g., `3.5.21.0`). Even if you want to install version `3.5.21.2`, you have to define the generation as `3.5.21.0`. The patch version is defined by the `patch` input. | false | `3.5.21.0` |
 | `architecture` | The installation architecture of CODESYS. Allowed inputs: `32` and `64`. | false | `64` |
 | `patch` | The patch of the CODESYS version to install. | false | `0` |

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   installer-version:
     description: "The version of the installer to use to install the CODESYS installation."
     required: false
-    default: 2.5.0.0
+    default: 2.6.0.0
 
   generation:
     description: >


### PR DESCRIPTION
This pull request updates the default CODESYS installer and patch versions throughout the project to ensure the latest versions are used in both documentation and CI workflows. Most notably, it upgrades the default `installer-version` from `2.5.0.0` to `2.6.0.0` and the default patch for generation `3.5.21.0` from `3` to `4`. These changes affect the GitHub Actions workflow, documentation, and action configuration.

**CI/CD Workflow Updates:**

* Updated all occurrences of `installer-version` from `2.5.0.0` to `2.6.0.0` in `.github/workflows/setup.yml` to ensure the CI uses the latest installer by default. [[1]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L25-R25) [[2]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L69-R69) [[3]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L105-R108) [[4]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L138-R141) [[5]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L170-R173) [[6]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L206-R209) [[7]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L236-R236) [[8]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L246-R246) [[9]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L256-R256) [[10]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L293-R293) [[11]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L334-R334) [[12]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L352-R352) [[13]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L391-R391) [[14]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L402-R402)
* Changed the default patch version for generation `3.5.21.0` from `3` to `4` in all relevant workflow matrix and job definitions. [[1]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L56-R56) [[2]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L105-R108) [[3]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L138-R141) [[4]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L170-R173) [[5]](diffhunk://#diff-21b2bb33643eb2ddec63535b53d81e3dbf12907d4ead032a90327495ff3e7641L206-R209)

**Documentation and Configuration:**

* Updated the example usage and documentation in `README.md` to reflect the new default `installer-version` (`2.6.0.0`) and patch (`4`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R87)
* Changed the default value for `installer-version` in `action.yml` to `2.6.0.0`.

These updates help ensure consistency and that users and CI pipelines are working with the latest recommended versions by default.